### PR TITLE
Performance and compatibility improvements

### DIFF
--- a/K8s/helm/templates/mongodb-deployment.yaml
+++ b/K8s/helm/templates/mongodb-deployment.yaml
@@ -24,9 +24,11 @@ spec:
         ports:
         - containerPort: 27017
         resources:
+          {{ if .Values.databases.applyResourceLimits }}
           limits:
             cpu: 100m
             memory: 300Mi
+          {{ end }}
           requests:
             cpu: 100m
             memory: 300Mi

--- a/K8s/helm/templates/mysql-deployment.yaml
+++ b/K8s/helm/templates/mysql-deployment.yaml
@@ -28,9 +28,11 @@ spec:
         ports:
         - containerPort: 3306
         resources:
+          {{ if .Values.databases.applyResourceLimits }}
           limits:
             cpu: 300m
             memory: 1400Mi
+          {{ end }}
           requests:
             cpu: 300m
             memory: 1400Mi

--- a/K8s/helm/templates/payment-deployment.yaml
+++ b/K8s/helm/templates/payment-deployment.yaml
@@ -52,6 +52,12 @@ spec:
             cpu: 200m
             memory: 100Mi
       restartPolicy: Always
+      {{ if .Values.payment.increaseMaxConn }}
+      securityContext:
+        sysctls:
+        - name: net.core.somaxconn
+          value: "200"
+      {{ end }}
       {{- with .Values.payment.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/K8s/helm/templates/rabbitmq-deployment.yaml
+++ b/K8s/helm/templates/rabbitmq-deployment.yaml
@@ -87,6 +87,16 @@ metadata:
     service: rabbitmq
 spec:
   replicas: 1
+  {{ if .Values.rootOnlyFilesystem }}
+  override:
+    statefulSet:
+      spec:
+      template:
+          spec:
+            containers: []
+            initContainers: []
+            securityContext: {}
+  {{ end }}
   resources:
     limits:
       cpu: 500m

--- a/K8s/helm/templates/redis-statefulset.yaml
+++ b/K8s/helm/templates/redis-statefulset.yaml
@@ -28,13 +28,18 @@ spec:
           - name: data
             mountPath: /mnt/redis
         resources:
+          {{ if .Values.databases.applyResourceLimits }}
           limits:
             cpu: 200m
             memory: 100Mi
+          {{ end }}
           requests:
             cpu: 200m
             memory: 100Mi
       restartPolicy: Always
+      {{ if .Values.rootOnlyFilesystem }}
+      securityContext: {}
+      {{ end }}
       {{- with .Values.redis.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/K8s/helm/templates/shipping-deployment.yaml
+++ b/K8s/helm/templates/shipping-deployment.yaml
@@ -32,13 +32,20 @@ spec:
       - name: shipping
         image: {{ .Values.image.repo }}/rs-shipping:{{ .Values.image.version }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        # Configure memory allocation in case of heap space failures
+        command:
+        - "java"
+        - "-XX:InitialRAMPercentage=33"
+        - "-XX:MaxRAMPercentage=75"
+        - "-jar"
+        - "shipping.jar"
         ports:
         - containerPort: 8080
         # it's Java it needs lots of memory
         resources:
           limits:
             cpu: 1000m
-            memory: 1024Mi
+            memory: 4Gi
           requests:
             cpu: 1000m
             memory: 1024Mi

--- a/K8s/helm/values.yaml
+++ b/K8s/helm/values.yaml
@@ -12,6 +12,14 @@ eum:
   url: https://eum-eu-west-1.instana.io
   #url: https://eum-us-west-2.instana.io
 
+databases:
+  # define whether databases should also be resource-constrained
+  applyResourceLimits: true
+
+# Some Kubernetes filesystems (e.g. IBM Cloud Gold) require root access to volumes (set to true to change security context for rabbitmq and redis
+# which be default run as non-root 
+rootOnlyFilesystem: false
+
 # Pod Security Policy
 psp:
   enabled: false
@@ -48,6 +56,8 @@ payment:
   # Default is https://www.paypal.com
   gateway: null
   #gateway: https://www.worldpay.com
+  # some Linux and Kubernetes distros (e.g. Minikube) use maxconn limit of 128, payment requires 200, set to true if required
+  increaseMaxConn: false
 
 rabbitmq: {}
 
@@ -60,6 +70,8 @@ redis:
 shipping: {}
 
 user: {}
+
+web: {}
 
 instana:
   agent:


### PR DESCRIPTION
- Pull request contains adjustments to Helm-Based deployment, some for performance improvements, others for compatibility to root-only file systems

Change log:

[DATABASE RESOURCES]
- The helm chart now provides a config value to deactivate resource limits for databases (redis, mysql, mongodb), useful for testing pure horizontal service scaling to avoid unintended database bottlenecks
- Value applies resource limits by default (same as before update)

[COMPATIBILITY WITH MINIKUBE + RHEL/FEDORA]
- Some linux and Kubernetes distros force maxconn sysctl setting to be 128 by default
- Added a config value to explicitly increase maxconn value for payment service (required when you want to run robot-shop on Minikube + RHEL/Fedora)
- Default value does not explicitly increase maxconn value (same as before update)

[COMPATIBILITY WITH ROOT-ONLY FILESYSTEM]
- Depending on the cluster's persistent volume provider, containers might have to access volume as root user (e.g. in IBM cloud)
- Added config values to adjust security contexts of redis and rabbitmq, that do not run as root users be default
- Default value does not explicitly change security contexts (same as before update)

[MEMORY ALLOCATION OF SHIPPING SERVICE]
- It has been reported that shipping service crashes quite often under low load because of constrained heap space
- Overwritten start command to explicitly limit heap space relative to maximum RAM capacity (can now be easily adjusted in case memory is still not enough)
- Increased default RAM limit to 4Gi